### PR TITLE
Add Season 1 Info to Season Selector

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -52,15 +52,30 @@
     text-align: center;
 }
 
-.season-selector {
+.season-selector-outer {
     margin-top: 15px;
     margin-bottom: 10px;
+    max-width: fit-content;
+    width: 100%;
+    position: relative;
+    transition: all 0.3s cubic-bezier(0.17, 0.84, 0.44, 1);
+}
+
+.season-selector-outer:has(.season-1-info) {
+    margin-bottom: 40px;
+}
+
+.season-selector {
     width: 100%;
     overflow-x: auto;
     border: 1px solid rgba(255, 255, 255, 0.1);
     background: rgba(0, 0, 0, 0.3);
     border-radius: 5px;
     max-width: fit-content;
+}
+
+.season-selector:has(+ .season-1-info) {
+    border-radius: 5px 5px 0 0;
 }
 
 /* Screen reader only class for accessibility */
@@ -160,6 +175,42 @@ Alternative approach using adjacent sibling for older browsers
         border: 1px solid #02bae7;
     }
 } */
+
+.season-1-info {
+    position: absolute;
+    padding: 5px;
+    border: 1px solid #A3A300;
+    border-radius: 0 0 5px 5px;
+    /* background-color: #525200; */
+    background: repeating-linear-gradient(-45deg, #666600 0, #666600, 6px, #525200 6px, #525200 12px);
+    /* width: 100%;
+    box-sizing: border-box; */
+}
+
+/* Vue transition classes for season-info */
+.season-info-enter-active {
+    transition: all 0.3s cubic-bezier(0.17, 0.84, 0.44, 1);
+    transform-origin: top;
+}
+
+.season-info-leave-active {
+    transition: all 0.2s cubic-bezier(0.55, 0.06, 0.68, 0.19);
+    transform-origin: bottom;
+}
+
+.season-info-enter-from {
+    opacity: 0;
+    transform: translateY(-15px);
+}
+
+.season-info-leave-to {
+    opacity: 0;
+    transform: translateY(-10px);
+}
+
+.season-1-info p {
+    font-size: 12px;
+}
 
 .leaderboard-container {
     display: flex;

--- a/app/components/SeasonSelector.vue
+++ b/app/components/SeasonSelector.vue
@@ -1,13 +1,21 @@
 <template>
-	<div class="season-selector">
-		<fieldset class="season-tabs" role="radiogroup" aria-labelledby="season-selector-label">
-			<legend id="season-selector-label" class="sr-only">Select Season</legend>
-			<label v-for="season in availableSeasons" :key="season.value" class="season-tab">
-				<input type="radio" :value="season.value" v-model="modelValue" @change="handleSeasonChange" name="season" :aria-label="`Season ${season.value}`" />
-				<span>{{ season.label }}</span>
-			</label>
-		</fieldset>
+	<div class="season-selector-outer">
+		<div class="season-selector">
+			<fieldset class="season-tabs" role="radiogroup" aria-labelledby="season-selector-label">
+				<legend id="season-selector-label" class="sr-only">Select Season</legend>
+				<label v-for="season in availableSeasons" :key="season.value" class="season-tab">
+					<input type="radio" :value="season.value" v-model="modelValue" @change="handleSeasonChange" name="season" :aria-label="`Season ${season.value}`" />
+					<span>{{ season.label }}</span>
+				</label>
+			</fieldset>
+		</div>
+		<Transition name="season-info">
+			<div v-if="modelValue === 1" class="season-1-info">
+				<p>Season 1 data might contain inaccuracies or be incomplete because the data was stored on a broken Google Sheets file.</p>
+			</div>
+		</Transition>
 	</div>
+	 
 </template>
 
 <script setup>

--- a/app/pages/[name].vue
+++ b/app/pages/[name].vue
@@ -322,7 +322,7 @@
     max-width: 1800px;
 }
 
-.season-selector {
+.season-selector-outer {
     position: absolute;
     top: 0;
     left: 0;
@@ -828,7 +828,7 @@
         width: 100%;
     }
 
-    .season-selector {
+    .season-selector-outer {
         position: initial;
         margin-bottom: 10px;
     }


### PR DESCRIPTION
Since the player data from Season 1 originally came from the broken Google Sheets file we started Lounge on, player MMR, gains and losses and other data can be missing, inaccurate or completely false.

<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/5a226b61-5d77-4371-8428-96e9e3f82df0" />

### This PR adds the following information to the Season Selector when Season 1 is selected:

<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/e3079b88-a148-4bc9-b1b1-6672e4928a39" />

### Player Page
<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/7663499a-d364-4fbd-9cb8-eae8aeea43f3" />

### Leaderboard
<img width="1920" height="505" alt="image" src="https://github.com/user-attachments/assets/943aee99-44dc-499d-bb46-b1816833e484" />